### PR TITLE
Expand docs on githubstatus options

### DIFF
--- a/doc/manual/src/plugins.md
+++ b/doc/manual/src/plugins.md
@@ -98,15 +98,52 @@ configuration options:
 
 Sets GitHub CI status.
 
-configuration options:
+### Configuration options
 
 - `githubstatus.[].jobs`
+
+Regular expression for jobs to match in the format `project:jobset:job`.
+Defaults to `*:*:*`.
+
 - `githubstatus.[].excludeBuildFromContext`
+
+Don't include the build's ID in the status.
+
 - `githubstatus.[].context`
+
+Context shown in the status
+
 - `githubstatus.[].useShortContext`
+
+Renames `continuous-integration/hydra` to `ci/hydra` and removes the PR suffix
+from the name. Useful to see the full path in GitHub for long job names.
+
 - `githubstatus.[].description`
+
+Description shown in the status. Defaults to `Hydra build #<build-id> of
+<jobname>`
+
 - `githubstatus.[].inputs`
+
+The input which corresponds to the github repo/rev whose
+status we want to report. Can be repeated.
+
 - `githubstatus.[].authorization`
+
+Verbatim contents of the Authorization header. See
+[GitHub documentaion](https://developer.github.com/v3/#authentication) for
+details.
+
+### Example
+
+```xml
+<githubstatus>
+  jobs = test:pr:build
+  inputs = src
+  authorization = Basic notgivingyoumypasswordosorry
+  excludeBuildFromContext = 1
+</githubstatus>
+```
 
 ## Gitlab pulls
 


### PR DESCRIPTION
Add descriptions for the `githubstatus` options and a working example of the config. 
Information taken from: 

- https://github.com/NixOS/hydra/pull/280
- https://github.com/Infinisil/hydra/commit/a6d9201947aa1468d31ef5c2651251ceeefceb5c#diff-a79a90b20efc79d27f483e034c0b277bd67a18eeb5a90856303d076fe8ad7494
- https://git.m-labs.hk/M-Labs/it-infra/src/commit/8ad847c7fa5946cadfd10d2a5449270e4941ac69/nixbld-etc-nixos/configuration.nix
- https://nix-dev.science.uu.narkive.com/ZCalkcJ8/hydra-github-status-plugin