### PR TITLE
hydra-plugins: replace jq with perl's own canonical json output

### DIFF
--- a/nixos-modules/hydra.nix
+++ b/nixos-modules/hydra.nix
@@ -364,7 +364,7 @@ in
         requires = [ "hydra-init.service" ];
         restartTriggers = [ hydraConf ];
         after = [ "hydra-init.service" "network.target" ];
-        path = with pkgs; [ hostname-debian cfg.package jq ];
+        path = with pkgs; [ hostname-debian cfg.package ];
         environment = env // {
           HYDRA_DBI = "${env.HYDRA_DBI};application_name=hydra-evaluator";
         };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Improvements
  * Deterministic, human-readable JSON outputs for VCS integrations (Bitbucket, GitHub, GitLab), improving reproducibility and debuggability.
* Bug Fixes
  * Removed nondeterministic sorting stemming from external tooling, ensuring stable output ordering.
* Chores
  * Eliminated the external jq dependency across related services/plugins.
  * Streamlined service environment paths to reduce unnecessary tools in runtime PATH.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->